### PR TITLE
First cut at Sngl ifos handling

### DIFF
--- a/approval_processorMPutils.py
+++ b/approval_processorMPutils.py
@@ -10,7 +10,6 @@ from eventDictClassMethods import *
 from approval_processorMPcommands import parseCommand
 
 from lvalertMP.lvalert import lvalertMPutils as utils
-from ligo.gracedb.rest import GraceDb, HTTPError
 
 import os
 import json
@@ -23,10 +22,10 @@ import re
 # Activate a virtualenv in order to be able to use Comet.
 #-----------------------------------------------------------------------
 
-VIRTUALENV_ACTIVATOR = "/home/alexander.pace/emfollow_gracedb/cometenv/bin/activate_this.py" ### FIXME: this shouldn't be hard coded like this. 
+#VIRTUALENV_ACTIVATOR = "/home/alexander.pace/emfollow_gracedb/cometenv/bin/activate_this.py" ### FIXME: this shouldn't be hard coded like this. 
                                                                                              ### If we need a virtual environment, it should be distributed along with the package.
                                                                                              ### That way, it is straightforward to install and run the code from *any* computer withour modifying the source code
-execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
+#execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
 
 #--------------------
 # Definitions of which checks must be satisfied in each state before moving on
@@ -34,6 +33,7 @@ execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
 
 # main checks when currentstate of event is new_to_preliminary
 new_to_preliminary = [
+    'ifosCheck',
     'farCheck',
     'labelCheck',
     'injectionCheck'
@@ -85,7 +85,7 @@ def parseAlert(queue, queueByGraceID, alert, t0, config):
 
     # instantiate GraceDB client from the childConfig
     client = config.get('general', 'client')
-    g = GraceDb(client)
+    g = initGraceDb(client)
 
     # get other childConfig settings; save in configdict
     voeventerror_email        = config.get('general', 'voeventerror_email')
@@ -301,7 +301,7 @@ def parseAlert(queue, queueByGraceID, alert, t0, config):
 
     # actions for each alert_type
     currentstate = event_dict.data['currentstate'] ### actions depend on the current state
-       
+
     ### NOTE: we handle alert_type=="new" above as well and this conditional is slightly redundant...
     if alert_type=='new':
 

--- a/approval_processorMPutils.py
+++ b/approval_processorMPutils.py
@@ -22,10 +22,10 @@ import re
 # Activate a virtualenv in order to be able to use Comet.
 #-----------------------------------------------------------------------
 
-#VIRTUALENV_ACTIVATOR = "/home/alexander.pace/emfollow_gracedb/cometenv/bin/activate_this.py" ### FIXME: this shouldn't be hard coded like this. 
+VIRTUALENV_ACTIVATOR = "/home/alexander.pace/emfollow_gracedb/cometenv/bin/activate_this.py" ### FIXME: this shouldn't be hard coded like this. 
                                                                                              ### If we need a virtual environment, it should be distributed along with the package.
                                                                                              ### That way, it is straightforward to install and run the code from *any* computer withour modifying the source code
-#execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
+execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
 
 #--------------------
 # Definitions of which checks must be satisfied in each state before moving on

--- a/queueItemsAndTasks.py
+++ b/queueItemsAndTasks.py
@@ -5,7 +5,6 @@ author = "Min-A Cho (mina19@umd.edu), Reed Essick (reed.essick@ligo.org)"
 
 from eventDictClassMethods import *
 from lvalertMP.lvalert import lvalertMPutils as utils
-from ligo.gracedb.rest import GraceDb
 
 import time
 
@@ -161,7 +160,7 @@ class PipelineThrottle(utils.QueueItem):
 
         self.computeNthr() ### sets self.Nthr
 
-        self.graceDB = GraceDb( graceDB_url )
+        self.graceDB = initGraceDb( graceDB_url )
 
         tasks = [Throttle(self.events, eventDicts, grouperWin, win, self.Nthr, requireManualReset=requireManualReset) ### there is only one task!
                 ]
@@ -443,7 +442,7 @@ class DefineGroup(utils.Task):
     def __init__(self, events, eventDicts, timeout, graceDB_url='https://gracedb.ligo.org/api'):
         self.events = events ### shared reference to events tracked within Grouper QueueItem
         self.eventDicts = eventDicts ### shared reference pointing to the local data about events
-        self.graceDB = GraceDb( graceDB_url )
+        self.graceDB = initGraceDb( graceDB_url )
         super(DefineGroup, self).__init__(timeout)
     def decide(self, verbose=False):
         '''


### PR DESCRIPTION
Hi Mina and Reed,
In this pull request, I am trying out first shot at handling single detector IFO events. 

- Intention, at this stage, being that neglecting single IFO events. 
- I have added a new check called ifosCheck in the set of new_to_preliminary checks and a new key in the event_dict.data ifosCheckresult. This just checks the # of IFOs involved in the event.
- This seems to fit in the natural logic of AP since the if any one of the checks fail, the event is labelled with
> new_to_preliminary --> rejected

I have checked this using lvalertTest. Attaching the log messages for two simulated events G000098 which is double IFO and G000099 which is single IFO (see bottom)

- Regarding external events and GRB coincidences, it seems like AP keeps track of GW GRB coincidences even when the GW event fails **new_to_preliminary** test.
For example, (https://gracedb.ligo.org/events/view/E280232) and (https://gracedb.ligo.org/events/G280231) where the GRB label was applied (and email sent to grb_email)



Pasting the contents of the AP log for the two test events (G000098(H1,L1) & G000099(H1))
`
2017-05-23 03:41:11 ************ approval_processorMP.log RESTARTED ************

2017-05-23 03:41:11 -- G000098 -- Created event dictionary for G000098.
2017-05-23 03:41:21 -- G000098 -- Low enough FAR. 7e-09 < 1.9e-07
2017-05-23 03:41:21 -- G000098 -- Passed all new_to_preliminary checks.
2017-05-23 03:41:22 -- G000098 -- Sending preliminary VOEvent.
2017-05-23 03:41:32 -- G000098 -- State: new_to_preliminary --> preliminary_to_initial.
2017-05-23 03:41:32 -- G000098 -- Not all operators have signed off yet.
2017-05-23 03:41:32 -- G000098 -- Advocates have not signed off yet.
2017-05-23 03:41:32 -- G000098 -- Got H1OPS label.
2017-05-23 03:41:33 -- G000098 -- Got L1OPS label.
2017-05-23 03:41:33 -- G000098 -- Got the minfap for L using ovl is 0.854829.
2017-05-23 03:41:33 -- G000098 -- Got the minfap for H using ovl is 0.022213.
2017-05-23 03:41:33 -- G000098 -- Got ADVREQ label.
2017-05-23 03:42:02 -- G000098 -- Got the lvem skymap lalinference_skymap.fits.gz.
2017-05-23 03:42:02 -- G000098 -- Initial skymap tagged lvem lalinference_skymap.fits.gz available.
2017-05-23 03:42:09 -- G000098 -- Got the lvem skymap bayestar.fits.gz.
2017-05-23 03:42:09 -- G000098 -- Initial skymap tagged lvem bayestar.fits.gz available.
2017-05-23 03:43:21 -- G000099 -- Created event dictionary for G000099.
2017-05-23 03:43:32 -- G000099 -- Rejecting due to Single IFO H1
2017-05-23 03:43:32 -- G000099 -- Failed ifosCheck in currentstate: new_to_preliminary.
2017-05-23 03:43:32 -- G000099 -- State: new_to_preliminary --> rejected.
2017-05-23 03:43:33 -- G000099 -- Got the minfap for L using ovl is 0.122785.
2017-05-23 03:43:33 -- G000099 -- Got the minfap for H using ovl is 0.008676.
2017-05-23 03:43:33 -- G000099 -- Got ADVREQ label.
2017-05-23 03:43:34 -- G000099 -- Got H1OPS label.
2017-05-23 03:44:23 -- G000099 -- Got the lvem skymap lalinference_skymap.fits.gz.
2017-05-23 03:44:25 -- G000099 -- Got the lvem skymap bayestar.fits.gz.
`