### PR TITLE
Adding single IFO check in list of checks for new_to_preliminary

### DIFF
--- a/approval_processorMPutils.py
+++ b/approval_processorMPutils.py
@@ -10,7 +10,6 @@ from eventDictClassMethods import *
 
 from lvalertMP.lvalert import lvalertMPutils as utils
 from lvalertMP.lvalert.commands import parseCommand
-from ligo.gracedb.rest import GraceDb, HTTPError
 
 import os
 import json
@@ -34,6 +33,7 @@ execfile(VIRTUALENV_ACTIVATOR, dict(__file__=VIRTUALENV_ACTIVATOR))
 
 # main checks when currentstate of event is new_to_preliminary
 new_to_preliminary = [
+    'ifosCheck',
     'farCheck',
     'labelCheck',
     'injectionCheck'
@@ -85,7 +85,7 @@ def parseAlert(queue, queueByGraceID, alert, t0, config):
 
     # instantiate GraceDB client from the childConfig
     client = config.get('general', 'client')
-    g = GraceDb(client)
+    g = initGraceDb(client)
 
     # get other childConfig settings; save in configdict
     voeventerror_email        = config.get('general', 'voeventerror_email')

--- a/eventDictClassMethods.py
+++ b/eventDictClassMethods.py
@@ -37,6 +37,22 @@ eventDicts = {} # it's a dictionary storing data in the form 'graceid': event_di
 global eventDictionaries # global variable for local bookkeeping
 ### important thing is it saves the event_dict as a DICTIONARY
 eventDictionaries = {}
+#-----------------------------------------------------------------------
+# Define initGracedb() function
+#-----------------------------------------------------------------------
+def initGraceDb(client):
+    if 'http' in client:
+        g = GraceDb(client)
+    else:
+        # assume local path to FAKE_DB is passed
+        from ligoTest.gracedb.rest import FakeDb
+        # FakeDb directory is created if non-existent
+        if os.path.exists(client):
+            g = FakeDb(client)
+        else:
+            g = None
+    return g
+#-----------------------------------------------------------------------
 
 #-----------------------------------------------------------------------
 # EventDict class
@@ -79,6 +95,8 @@ class EventDict():
             'idq_joint_fapCheckresult'   : None,
             'idqlogkey'                  : 'no',
             'idqvalues'                  : {},
+            'ifoslogkey'                 : 'no',
+            'ifosCheckresult'            : None,
             'injectionCheckresult'       : None,
             'injectionsfound'            : None,
             'injectionlogkey'            : 'no',
@@ -190,6 +208,20 @@ class EventDict():
             'loggermessages'   : [],
             'pipeline'         : self.dictionary['pipeline']
         })  
+    #-----------------------------------------------------------------------
+    # ifosCheck
+    #-----------------------------------------------------------------------
+    def ifosCheck(self):
+        ifos = self.data['instruments']
+        res = len(ifos) > 1 # to neglect single IFO triggers 
+        self.data['ifosCheckresult'] = res
+        if not(res):
+            self.client.writeLog(self.graceid, 'AP: Candidate event rejected due to Single IFO')
+            self.data['ifoslogkey'] = 'yes'
+            message = '{0} -- {1} -- Rejecting due to Single IFO {2}'.format(convertTime(), self.graceid, ifos[0])
+            if loggerCheck(self.data, message)==False:
+                self.logger.info(message)
+        return res
 
     #-----------------------------------------------------------------------
     # farCheck
@@ -1021,7 +1053,7 @@ def resend_alert():
     client = config.get('general', 'client')
     approval_processorMPfiles = config.get('general', 'approval_processorMPfiles')
     print 'got client: {0}'.format(client)
-    g = GraceDb('{0}'.format(client))
+    g = initGraceDb('{0}'.format(client))
 
     # set up logger
     logger = loadLogger(config)
@@ -1065,7 +1097,7 @@ def resend_alert():
 def createTestEventDict(graceid):
     config = loadConfig()
     client = config.get('general', 'client')
-    g = GraceDb(client)
+    g = initGraceDb(client)
     configdict = makeConfigDict(config)
     logger = loadLogger(config)
     event_dict = EventDict()

--- a/queueItemsAndTasks.py
+++ b/queueItemsAndTasks.py
@@ -5,7 +5,6 @@ author = "Min-A Cho (mina19@umd.edu), Reed Essick (reed.essick@ligo.org)"
 
 from eventDictClassMethods import *
 from lvalertMP.lvalert import lvalertMPutils as utils
-from ligo.gracedb.rest import GraceDb
 
 import time
 
@@ -144,7 +143,7 @@ class PipelineThrottle(utils.QueueItem):
 
         self.computeNthr() ### sets self.Nthr
 
-        self.graceDB = GraceDb( graceDB_url )
+        self.graceDB = initGraceDb( graceDB_url )
 
         tasks = [Throttle(self.events, win, self.Nthr, requireManualReset=requireManualReset) ### there is only one task!
                 ]
@@ -407,7 +406,7 @@ class DefineGroup(utils.Task):
     def __init__(self, events, eventDicts, timeout, graceDB_url='https://gracedb.ligo.org/api'):
         self.events = events ### shared reference to events tracked within Grouper QueueItem
         self.eventDicts = eventDicts ### shared reference pointing to the local data about events
-        self.graceDB = GraceDb( graceDB_url )
+        self.graceDB = initGraceDb( graceDB_url )
         super(DefineGroup, self).__init__(timeout)
     def decide(self, verbose=False):
         '''


### PR DESCRIPTION
Hi @reedessick and @mina19 

Following up on the EM Review telecon on May 24, 2017,I'm  creating a new pull request on the 
SHA provided by Mina.

I ran the checks with FakeDb supplying a gstlal.ini config file (attached) with the "humans" section **commented out** and Group changed to **CBC** (!= Test). "CreateVOEvent" is not yet implemented in FakeDb and hence raised an exception. I will create an issue in lvalertTest on this.
[gstlal.txt](https://github.com/mina19/approval_processorMP/files/1027562/gstlal.txt)


Unlike last pull request, this time there are labels being applied (pasting output below). Although, I don't know about this being the expected behavior.

I started lvalertTest_listenMP and launched creation of a fake event using simulate.py
`deep@debian:~/FAKE_DB$ lvalertTest_listenMP -f /home/deep/FAKE_DB/ -c /home/deep/github_forked/approval_processorMP/etc/lvalert_listenMP-approval_processorMP.ini -v`

Supplying the config file (of course I did not push these)
[childConfig-approval_processorMP.txt](https://github.com/mina19/approval_processorMP/files/1027584/childConfig-approval_processorMP.txt)
[lvalert_listenMP-approval_processorMP.txt](https://github.com/mina19/approval_processorMP/files/1027585/lvalert_listenMP-approval_processorMP.txt)


Code to run simulate.py
`deep@debian:~/github_forked/approval_processorMP$ simulate.py -N 1 -r 3.0 -g /home/deep/FAKE_DB/ -i "H1,L1" -o /home/deep/OUT_DIR/ -s /home/deep/github_forked/lvalertTest/etc/gstlal.ini -v`

- Both events are __G000000__ since I cleared the FAKE_DB directory before each run,
- First one ran with two IFOS,
- Second one ran with single IFO

#################################################################

`
2017-05-24 18:22:02 ************ approval_processorMP.log RESTARTED ************

2017-05-24 18:22:02 -- G000000 -- Created event dictionary for G000000.
2017-05-24 18:22:12 -- G000000 -- Low enough FAR. 6e-09 < 1.9e-07
2017-05-24 18:22:14 -- G000000 -- No hardware injection found near event gpstime +/- 2.0 seconds.
2017-05-24 18:22:14 -- G000000 -- Passed all new_to_preliminary checks.
2017-05-24 18:22:14 -- G000000 -- Sending preliminary VOEvent.
2017-05-24 18:22:14 -- G000000 -- Creating preliminary VOEvent file locally.
2017-05-24 18:22:14 -- G000000 -- Caught HTTPError: FakeDb instance has no attribute 'createVOEvent'
2017-05-24 18:22:14 -- G000000 -- State: new_to_preliminary --> preliminary_to_initial.
2017-05-24 18:22:14 -- G000000 -- Labeling H1OPS.
2017-05-24 18:22:14 -- G000000 -- Labeling L1OPS.
2017-05-24 18:22:14 -- G000000 -- Labeling ADVREQ.
2017-05-24 18:22:15 -- G000000 -- Have not gotten all the minfap values yet.
2017-05-24 18:22:15 -- G000000 -- Not all operators have signed off yet.
2017-05-24 18:22:15 -- G000000 -- Advocates have not signed off yet.
2017-05-24 18:22:15 -- G000000 -- Got the minfap for H using ovl is 0.00401.
2017-05-24 18:22:15 -- G000000 -- iDQ check result: 0.00401 < 0.01
2017-05-24 18:22:15 -- G000000 -- Failed idq_joint_fapCheck in currentstate: preliminary_to_initial.
2017-05-24 18:22:15 -- G000000 -- State: preliminary_to_initial --> rejected.
2017-05-24 18:22:16 -- G000000 -- Labeling DQV.
2017-05-24 18:22:16 -- G000000 -- Got the minfap for L using ovl is 0.044433.
2017-05-24 18:22:18 -- G000000 -- Got H1OPS label.
2017-05-24 18:22:18 -- G000000 -- Got L1OPS label.
2017-05-24 18:22:18 -- G000000 -- Got ADVREQ label.
2017-05-24 18:22:19 -- G000000 -- Got DQV label.
2017-05-24 18:22:50 -- G000000 -- Got the lvem skymap lalinference_skymap.fits.gz.
2017-05-24 18:23:01 -- G000000 -- Got the lvem skymap bayestar.fits.gz.
 
2017-05-24 18:24:34 ************ approval_processorMP.log RESTARTED ************

2017-05-24 18:24:34 -- G000000 -- Created event dictionary for G000000.
2017-05-24 18:24:44 -- G000000 -- Rejecting due to Single IFO H1
2017-05-24 18:24:44 -- G000000 -- Failed ifosCheck in currentstate: new_to_preliminary.
2017-05-24 18:24:44 -- G000000 -- State: new_to_preliminary --> rejected.
2017-05-24 18:24:45 -- G000000 -- Got the minfap for L using ovl is 0.042483.
2017-05-24 18:24:45 -- G000000 -- Got the minfap for H using ovl is 0.002112.
2017-05-24 18:25:32 -- G000000 -- Got the lvem skymap lalinference_skymap.fits.gz.
2017-05-24 18:25:40 -- G000000 -- Got the lvem skymap bayestar.fits.gz.

`