### PR TITLE
Added logic to ifosCheck to neglect doubles with V1

### DIFF
--- a/eventDictClassMethods.py
+++ b/eventDictClassMethods.py
@@ -226,13 +226,17 @@ class EventDict():
     # ifosCheck
     #-----------------------------------------------------------------------
     def ifosCheck(self):
-        ifos = self.data['instruments']
-        res = len(ifos) > 1 # to neglect single IFO triggers 
+        ifos = self.data['instruments'] # instruments as a list
+        ifolist = ",".join(ifos)        # instrument list as a string
+        num_ifo = len(ifos)             # number of ifos
+        res = False if num_ifo == 1 else True if num_ifo == 3 \
+                                                 else 'V1' not in ifos
         self.data['ifosCheckresult'] = res
         if not(res):
-            self.client.writeLog(self.graceid, 'AP: Candidate event rejected due to Single IFO')
+            self.client.writeLog(self.graceid, \
+            'AP: Candidate event rejected due to single ifo OR V1 in double coinc')
             self.data['ifoslogkey'] = 'yes'
-            message = '{0} -- {1} -- Rejecting due to Single IFO {2}'.format(convertTime(), self.graceid, ifos[0])
+            message = '{0} -- {1} -- Rejecting due to single ifo OR presence of V1 in ifo list: {2}'.format(convertTime(), self.graceid, ifolist)
             if loggerCheck(self.data, message)==False:
                 self.logger.info(message)
         return res

--- a/eventDictClassMethods.py
+++ b/eventDictClassMethods.py
@@ -229,14 +229,14 @@ class EventDict():
         ifos = self.data['instruments'] # instruments as a list
         ifolist = ",".join(ifos)        # instrument list as a string
         num_ifo = len(ifos)             # number of ifos
-        res = False if num_ifo == 1 else True if num_ifo == 3 \
+        res = False if num_ifo == 1 else True if num_ifo >= 3 \
                                                  else 'V1' not in ifos
         self.data['ifosCheckresult'] = res
         if not(res):
             self.client.writeLog(self.graceid, \
-            'AP: Candidate event rejected due to single ifo OR V1 in double coinc')
+            'AP: Candidate event rejected due to single ifo OR V1 in two-ifo coinc')
             self.data['ifoslogkey'] = 'yes'
-            message = '{0} -- {1} -- Rejecting due to single ifo OR presence of V1 in ifo list: {2}'.format(convertTime(), self.graceid, ifolist)
+            message = '{0} -- {1} -- Rejecting due to single ifo OR presence of V1 in two-ifo coinc: {2}'.format(convertTime(), self.graceid, ifolist)
             if loggerCheck(self.data, message)==False:
                 self.logger.info(message)
         return res

--- a/test/pipelineThrottle/build_testing_config
+++ b/test/pipelineThrottle/build_testing_config
@@ -9,7 +9,7 @@ parser.add_argument('--file', required=True, help='File to write config file')
 parser.add_argument('--group', choices=['Test','CBC','Burst'], required=True)
 parser.add_argument('--pipeline',choices=['pycbc','gstlal','CWB','LIB'],required=True)
 parser.add_argument('--search', choices=['AllSky','HighMass','LowMass',None], default='None')
-parser.add_argument('--instruments',type=str, choices=["H1","L1","H1,L1",None], default="H1,L1")
+parser.add_argument('--instruments',type=str, choices=["H1","L1","V1","H1,V1","L1,V1","H1,L1","H1,L1,V1",None], default="H1,L1")
 ### Add human response options
 parser.add_argument('--humans',type=int,choices=[0,1], help='Adds humans section.  Supply boolean', default=0)
 parser.add_argument('--human-response',type=int, choices=[0,1], help='Adds humans section.  Enter 1 for ADVOK 0 for ADVNO', default=0)

--- a/test/pipelineThrottle/one_fake_gstlal_double_V1.sh
+++ b/test/pipelineThrottle/one_fake_gstlal_double_V1.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+REPO_DIR=$(cat repoDir.txt)
+
+# USAGE:: ./one_fake_gstlal.sh
+FAKE_DB=${REPO_DIR}/approval_processorMP/test/FAKE_DB		# Directory where events will be created
+OUT_DIR=${REPO_DIR}/approval_processorMP/test/OUT_DIR		# temporary directory to store upload files
+CONFIG_FILE=${REPO_DIR}/approval_processorMP/test/pipelineThrottle/gstlal.ini_1		# config file of the event created, will be written by script
+NUM_EVENTS=1		# number of this type of events to be created
+
+# Event details
+GROUP="CBC"
+PIPELINE="gstlal"
+SEARCH="LowMass"
+INSTRUMENTS="H1,V1"
+FAR=1e-8		# Event FAR
+HUMANS=0		# Add humans section?
+HUMAN_RESPONSE=1	# 0 for ADVNO, 1 for ADVOK
+SEGDB2GRCDB=0		# Add segdb2grcdb section?
+IDQ=0			# Add idq section?
+IDQ_RESPONSE=1		# Pass/ fail criteria AP's IDQ threshold
+SKYMAPS=0		# Adds various skymaps?
+LVEM=1			# Add lvem tag?
+EXT_TRIGGER=0		# Add ext-trigger section?
+UNBLIND_INJ=0		# Add unblind-inj section?
+
+if [ ! -d ${FAKE_DB} ];then
+	mkdir -p ${FAKE_DB}
+fi
+
+if [ ! -d ${OUT_DIR} ];then
+	mkdir -p ${OUT_DIR}
+fi
+
+if [ ! -d $(dirname ${CONFIG_FILE}) ];then
+	mkdir -p $(dirname ${CONFIG_FILE})
+fi
+
+if [ ! -f ${CONFIG_FILE} ];then
+	touch ${CONFIG_FILE}
+fi
+
+# Write the config file
+echo "### Writing config file"
+./build_testing_config \
+	--file=${CONFIG_FILE} \
+	--group=${GROUP} \
+	--pipeline=${PIPELINE} \
+	--search=${SEARCH} \
+	--instruments=${INSTRUMENTS} \
+	--humans=${HUMANS} \
+	--human-response=${HUMAN_RESPONSE} \
+	--segdb2grcdb=${SEGDB2GRCDB} \
+	--idq=${IDQ} \
+	--idq-response=${IDQ_RESPONSE} \
+	--skymaps=${SKYMAPS} \
+	--lvem=${LVEM} \
+	--ext-trigger=${EXT_TRIGGER} \
+	--unblind-inj=${UNBLIND_INJ}
+
+echo "### Config written to ${CONFIG_FILE}"
+echo "### Simulating fake event creation"
+
+${REPO_DIR}/lvalertTest/bin/simulate.py \
+	--num-events=${NUM_EVENTS} \
+	--far=${FAR} \
+	--gracedb-url=${FAKE_DB} \
+	--instruments=${INSTRUMENTS} \
+	--output-dir=${OUT_DIR} \
+	-s \
+	-v \
+	${CONFIG_FILE}

--- a/test/pipelineThrottle/one_fake_gstlal_triple.sh
+++ b/test/pipelineThrottle/one_fake_gstlal_triple.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+REPO_DIR=$(cat repoDir.txt)
+
+# USAGE:: ./one_fake_gstlal.sh
+FAKE_DB=${REPO_DIR}/approval_processorMP/test/FAKE_DB		# Directory where events will be created
+OUT_DIR=${REPO_DIR}/approval_processorMP/test/OUT_DIR		# temporary directory to store upload files
+CONFIG_FILE=${REPO_DIR}/approval_processorMP/test/pipelineThrottle/gstlal.ini_1		# config file of the event created, will be written by script
+NUM_EVENTS=1		# number of this type of events to be created
+
+# Event details
+GROUP="CBC"
+PIPELINE="gstlal"
+SEARCH="LowMass"
+INSTRUMENTS="H1,L1,V1"
+FAR=1e-8		# Event FAR
+HUMANS=0		# Add humans section?
+HUMAN_RESPONSE=1	# 0 for ADVNO, 1 for ADVOK
+SEGDB2GRCDB=0		# Add segdb2grcdb section?
+IDQ=0			# Add idq section?
+IDQ_RESPONSE=1		# Pass/ fail criteria AP's IDQ threshold
+SKYMAPS=0		# Adds various skymaps?
+LVEM=1			# Add lvem tag?
+EXT_TRIGGER=0		# Add ext-trigger section?
+UNBLIND_INJ=0		# Add unblind-inj section?
+
+if [ ! -d ${FAKE_DB} ];then
+	mkdir -p ${FAKE_DB}
+fi
+
+if [ ! -d ${OUT_DIR} ];then
+	mkdir -p ${OUT_DIR}
+fi
+
+if [ ! -d $(dirname ${CONFIG_FILE}) ];then
+	mkdir -p $(dirname ${CONFIG_FILE})
+fi
+
+if [ ! -f ${CONFIG_FILE} ];then
+	touch ${CONFIG_FILE}
+fi
+
+# Write the config file
+echo "### Writing config file"
+./build_testing_config \
+	--file=${CONFIG_FILE} \
+	--group=${GROUP} \
+	--pipeline=${PIPELINE} \
+	--search=${SEARCH} \
+	--instruments=${INSTRUMENTS} \
+	--humans=${HUMANS} \
+	--human-response=${HUMAN_RESPONSE} \
+	--segdb2grcdb=${SEGDB2GRCDB} \
+	--idq=${IDQ} \
+	--idq-response=${IDQ_RESPONSE} \
+	--skymaps=${SKYMAPS} \
+	--lvem=${LVEM} \
+	--ext-trigger=${EXT_TRIGGER} \
+	--unblind-inj=${UNBLIND_INJ}
+
+echo "### Config written to ${CONFIG_FILE}"
+echo "### Simulating fake event creation"
+
+${REPO_DIR}/lvalertTest/bin/simulate.py \
+	--num-events=${NUM_EVENTS} \
+	--far=${FAR} \
+	--gracedb-url=${FAKE_DB} \
+	--instruments=${INSTRUMENTS} \
+	--output-dir=${OUT_DIR} \
+	-s \
+	-v \
+	${CONFIG_FILE}

--- a/test/pipelineThrottle/simulateTriple.sh
+++ b/test/pipelineThrottle/simulateTriple.sh
@@ -1,0 +1,16 @@
+# source all of the testing repositories
+source setup.sh
+
+
+# send one fake CBC_gstlal_LowMass event which is a triple
+# this event should *not* be labeled as EM_Throttled
+# should pass ifosCheck
+./one_fake_gstlal_triple.sh
+
+sleep 30
+
+# send one fake CBC_gstlal_LowMass event which is a double
+# involving V1
+# this should *NOT* be labelled EM_Throttled but 
+# should fail ifosCheck
+./one_fake_gstlal_double_V1.sh


### PR DESCRIPTION
ifosCheck now neglects single detector trigger and doubles with V1 in them.
Test scripts created to check this. Running simulateTriple.sh will create one triple event which should pass ifosCheck followed by one double event with V1 which should fail ifosCheck