### PR TITLE
Addition of VirgoDQ and virgo injections tests

### DIFF
--- a/test/virgoImplementation/build_testing_config
+++ b/test/virgoImplementation/build_testing_config
@@ -9,7 +9,7 @@ parser.add_argument('--file', required=True, help='File to write config file')
 parser.add_argument('--group', choices=['Test','CBC','Burst'], required=True)
 parser.add_argument('--pipeline',choices=['pycbc','gstlal','CWB','LIB'],required=True)
 parser.add_argument('--search', choices=['AllSky','HighMass','LowMass',None], default='None')
-parser.add_argument('--instruments',type=str, choices=["H1","L1","V1","H1,V1","V1,H1","L1,V1","V1,L1","H1,L1","L1,H1","H1,L1,V1","H1,V1,L1","V1,H1,L1","V1,L1,H1","L1,H1,V1","L1,V1,H1",None], default="H1,L1")
+parser.add_argument('--instruments',type=str, choices=["H1","L1","V1","H1,V1","L1,V1","H1,L1","H1,L1,V1",None], default="H1,L1")
 ### Add human response options
 parser.add_argument('--humans',type=int,choices=[0,1], help='Adds humans section.  Supply boolean', default=0)
 parser.add_argument('--human-response',type=int, choices=[0,1], help='Adds humans section.  Enter 1 for ADVOK 0 for ADVNO', default=0)
@@ -18,6 +18,9 @@ parser.add_argument('--segdb2grcdb',type=int,choices=[0,1],help='Adds segdb2grcd
 ### Add IDQ requirement options
 parser.add_argument('--idq',type=int,choices=[0,1], help='Adds idq section. Supply boolean', default=0)
 parser.add_argument('--idq-response',type=int,choices=[0,1], help='Enter 1 for passing IDQ, 0 otherwise', default=0)
+### Add VirgoDQ requirement options
+parser.add_argument('--virgodq',type=int,choices=[0,1], help='Adds VirgoDQ section. Supply boolean', default=0)
+parser.add_argument('--virgodq-veto',type=int,choices=[0,1], help='Enter 1 for passing data quality check, 0 otherwise', default=1)
 ### Add plot skymaps
 parser.add_argument('--skymaps',type=int,choices=[0,1], help='Adds skymap section',default=0)
 parser.add_argument('--lvem',type=int,choices=[0,1], help='Provide the lvem tag or not? Supply boolean', default=0)
@@ -28,8 +31,8 @@ parser.add_argument('--unblind-inj', type=int,choices=[0,1],help='Adds unblind i
 
 args = parser.parse_args()
 ### Peform argument dependency checks
-if args.group not in ['CBC','Test'] and args.idq:
-	parser.error("Only --group=CBC can have idq set")
+if args.group not in ['CBC','Test'] and (args.idq or args.virgodq):
+	parser.error("Only --group=CBC can have idq or virgodq set")
 	sys.exit(1)
 
 config = SafeConfigParser()
@@ -70,6 +73,32 @@ if args.segdb2grcdb:
 	config.set('L1:DMT-ANALYSIS_READY:1','prob','1')
 	config.set('L1:DMT-ANALYSIS_READY:1','win','30')
 
+if args.virgodq:
+    config.add_section('VirgoDQ')
+    config.set('VirgoDQ','instruments',args.instruments.replace(',',' '))
+    config.set('VirgoDQ','start delay','10.0')
+    config.set('VirgoDQ','start jitter' ,'1.0')
+    config.set('VirgoDQ','start prob','1.0')
+    
+    config.set('VirgoDQ','ifostats delay','1.0')
+    config.set('VirgoDQ','ifostats jitter','0.5')
+    config.set('VirgoDQ','ifostats prob','1.0')
+    
+    config.set('VirgoDQ','vetoes delay','1.0')
+    config.set('VirgoDQ','vetoes jitter','0.5')
+    config.set('VirgoDQ','vetoes prob', str(args.virgodq_veto))
+    
+    config.set('VirgoDQ','rmsChan delay','1.0')
+    config.set('VirgoDQ','rmsChan jitter','0.5')
+    config.set('VirgoDQ','rmsChan prob','1.0')
+    
+    config.set('VirgoDQ','inj delay','1.0')
+    config.set('VirgoDQ','inj jitter','0.5')
+    config.set('VirgoDQ','inj prob','1.0')
+    
+    config.set('VirgoDQ', 'pad left','10.0')
+    config.set('VirgoDQ', 'pad right','10.0')
+    
 if args.idq:
 	config.add_section('idq')
 	config.set('idq','instruments',args.instruments.replace(',',' '))

--- a/test/virgoImplementation/build_testing_config
+++ b/test/virgoImplementation/build_testing_config
@@ -21,6 +21,7 @@ parser.add_argument('--idq-response',type=int,choices=[0,1], help='Enter 1 for p
 ### Add VirgoDQ requirement options
 parser.add_argument('--virgodq',type=int,choices=[0,1], help='Adds VirgoDQ section. Supply boolean', default=0)
 parser.add_argument('--virgodq-veto',type=int,choices=[0,1], help='Enter 1 for passing data quality check, 0 otherwise', default=1)
+parser.add_argument('--virgo-inj',type=int,choices=[0,1], help='Enter 1 for having a virgo inj, 0 otherwise', default=0)
 ### Add plot skymaps
 parser.add_argument('--skymaps',type=int,choices=[0,1], help='Adds skymap section',default=0)
 parser.add_argument('--lvem',type=int,choices=[0,1], help='Provide the lvem tag or not? Supply boolean', default=0)
@@ -30,10 +31,7 @@ parser.add_argument('--ext-trigger', type=int,choices=[0,1],help='Adds external 
 parser.add_argument('--unblind-inj', type=int,choices=[0,1],help='Adds unblind injections section. Supply boolean',default=0)
 
 args = parser.parse_args()
-### Peform argument dependency checks
-if args.group not in ['CBC','Test'] and (args.idq or args.virgodq):
-	parser.error("Only --group=CBC can have idq or virgodq set")
-	sys.exit(1)
+
 
 config = SafeConfigParser()
 config.add_section('general')
@@ -94,7 +92,7 @@ if args.virgodq:
     
     config.set('VirgoDQ','inj delay','1.0')
     config.set('VirgoDQ','inj jitter','0.5')
-    config.set('VirgoDQ','inj prob','1.0')
+    config.set('VirgoDQ','inj prob',str(args.virgo_inj))
     
     config.set('VirgoDQ', 'pad left','10.0')
     config.set('VirgoDQ', 'pad right','10.0')

--- a/test/virgoImplementation/build_testing_config
+++ b/test/virgoImplementation/build_testing_config
@@ -9,7 +9,7 @@ parser.add_argument('--file', required=True, help='File to write config file')
 parser.add_argument('--group', choices=['Test','CBC','Burst'], required=True)
 parser.add_argument('--pipeline',choices=['pycbc','gstlal','CWB','LIB'],required=True)
 parser.add_argument('--search', choices=['AllSky','HighMass','LowMass',None], default='None')
-parser.add_argument('--instruments',type=str, choices=["H1","L1","V1","H1,V1","L1,V1","H1,L1","H1,L1,V1",None], default="H1,L1")
+parser.add_argument('--instruments',type=str, choices=["H1","L1","V1","H1,V1","V1,H1","L1,V1","V1,L1","H1,L1","L1,H1","H1,L1,V1","H1,V1,L1","V1,H1,L1","V1,L1,H1","L1,H1,V1","L1,V1,H1",None], default="H1,L1")
 ### Add human response options
 parser.add_argument('--humans',type=int,choices=[0,1], help='Adds humans section.  Supply boolean', default=0)
 parser.add_argument('--human-response',type=int, choices=[0,1], help='Adds humans section.  Enter 1 for ADVOK 0 for ADVNO', default=0)

--- a/test/virgoImplementation/one_fake_gstlal_triple.sh
+++ b/test/virgoImplementation/one_fake_gstlal_triple.sh
@@ -3,10 +3,10 @@
 REPO_DIR=$(cat repoDir.txt)
 
 # USAGE:: ./one_fake_gstlal.sh
-FAKE_DB=${REPO_DIR}/approval_processorMP/test/FAKE_DB		# Directory where events will be created
-OUT_DIR=${REPO_DIR}/approval_processorMP/test/OUT_DIR		# temporary directory to store upload files
-CONFIG_FILE=${REPO_DIR}/approval_processorMP/test/virgoImplementation/gstlal.ini_1		# config file of the event created, will be written by script
-NUM_EVENTS=1		# number of this type of events to be created
+FAKE_DB=${REPO_DIR}/approval_processorMP/test/FAKE_DB          # Directory where events will be created
+OUT_DIR=${REPO_DIR}/approval_processorMP/test/OUT_DIR          # temporary directory to store upload files
+CONFIG_FILE=${REPO_DIR}/approval_processorMP/test/virgoImplementation/gstlal.ini_1             # config file of the event created, will be written by script
+NUM_EVENTS=1
 
 # Event details
 GROUP="CBC"
@@ -14,13 +14,15 @@ PIPELINE="gstlal"
 SEARCH="LowMass"
 INSTRUMENTS="H1,L1,V1"
 FAR=1e-8		# Event FAR
-HUMANS=0		# Add humans section?
+HUMANS=1		# Add humans section?
 HUMAN_RESPONSE=1	# 0 for ADVNO, 1 for ADVOK
-SEGDB2GRCDB=0		# Add segdb2grcdb section?
-IDQ=0			# Add idq section?
+SEGDB2GRCDB=1		# Add segdb2grcdb section?
+VIRGODQ=1		# Add VirgoDQ section?
+VIRGODQVETO=0		# Pass/ fail Virgo DQ test
+IDQ=1			# Add idq section?
 IDQ_RESPONSE=1		# Pass/ fail criteria AP's IDQ threshold
 SKYMAPS=0		# Adds various skymaps?
-LVEM=1			# Add lvem tag?
+LVEM=0			# Add lvem tag?
 EXT_TRIGGER=0		# Add ext-trigger section?
 UNBLIND_INJ=0		# Add unblind-inj section?
 
@@ -51,6 +53,8 @@ echo "### Writing config file"
 	--humans=${HUMANS} \
 	--human-response=${HUMAN_RESPONSE} \
 	--segdb2grcdb=${SEGDB2GRCDB} \
+	--virgodq=${VIRGODQ} \
+	--virgodq-veto=${VIRGODQVETO} \
 	--idq=${IDQ} \
 	--idq-response=${IDQ_RESPONSE} \
 	--skymaps=${SKYMAPS} \

--- a/test/virgoImplementation/one_fake_gstlal_virgodq.sh
+++ b/test/virgoImplementation/one_fake_gstlal_virgodq.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+REPO_DIR=$(cat repoDir.txt)
+
+# USAGE:: ./one_fake_gstlal.sh
+FAKE_DB=${REPO_DIR}/approval_processorMP/test/FAKE_DB          # Directory where events will be created
+OUT_DIR=${REPO_DIR}/approval_processorMP/test/OUT_DIR          # temporary directory to store upload files
+CONFIG_FILE=${REPO_DIR}/approval_processorMP/test/virgoImplementation/gstlal.ini_1             # config file of the event created, will be written by script
+NUM_EVENTS=1
+
+# Event details
+GROUP="CBC"
+PIPELINE="gstlal"
+SEARCH="LowMass"
+INSTRUMENTS="H1,L1,V1"
+FAR=1e-8		# Event FAR
+HUMANS=1		# Add humans section?
+HUMAN_RESPONSE=1	# 0 for ADVNO, 1 for ADVOK
+SEGDB2GRCDB=0		# Add segdb2grcdb section?
+VIRGODQ=1		# Add VirgoDQ section?
+VIRGODQRESPONSE=1	# 0 for IS vetoed (fail); 1 for IS NOT vetoed (pass)
+VIRGOINJ=0		# 0 for DID NOT FIND injections; 1 for FOUND injections
+IDQ=1			# Add idq section?
+IDQ_RESPONSE=1		# Pass/ fail criteria AP's IDQ threshold
+SKYMAPS=0		# Adds various skymaps?
+LVEM=0			# Add lvem tag?
+EXT_TRIGGER=0		# Add ext-trigger section?
+UNBLIND_INJ=0		# Add unblind-inj section?
+
+if [ ! -d ${FAKE_DB} ];then
+	mkdir -p ${FAKE_DB}
+fi
+
+if [ ! -d ${OUT_DIR} ];then
+	mkdir -p ${OUT_DIR}
+fi
+
+if [ ! -d $(dirname ${CONFIG_FILE}) ];then
+	mkdir -p $(dirname ${CONFIG_FILE})
+fi
+
+if [ ! -f ${CONFIG_FILE} ];then
+	touch ${CONFIG_FILE}
+fi
+
+# Write the config file
+echo "### Writing config file"
+./build_testing_config \
+	--file=${CONFIG_FILE} \
+	--group=${GROUP} \
+	--pipeline=${PIPELINE} \
+	--search=${SEARCH} \
+	--instruments=${INSTRUMENTS} \
+	--humans=${HUMANS} \
+	--human-response=${HUMAN_RESPONSE} \
+	--segdb2grcdb=${SEGDB2GRCDB} \
+	--virgodq=${VIRGODQ} \
+	--virgodq-veto=${VIRGODQRESPONSE} \
+	--virgo-inj=${VIRGOINJ} \
+	--idq=${IDQ} \
+	--idq-response=${IDQ_RESPONSE} \
+	--skymaps=${SKYMAPS} \
+	--lvem=${LVEM} \
+	--ext-trigger=${EXT_TRIGGER} \
+	--unblind-inj=${UNBLIND_INJ}
+
+echo "### Config written to ${CONFIG_FILE}"
+echo "### Simulating fake event creation"
+
+${REPO_DIR}/lvalertTest/bin/simulate.py \
+	--num-events=${NUM_EVENTS} \
+	--far=${FAR} \
+	--gracedb-url=${FAKE_DB} \
+	--instruments=${INSTRUMENTS} \
+	--output-dir=${OUT_DIR} \
+	-s \
+	-v \
+	${CONFIG_FILE}


### PR DESCRIPTION
Hi @mina19 ,
This pull request modifies content of the test directory only. There are new arguments added to build_testing_config to handle virgo injections and virgo dq, These are essentially comments in the log messages, just like Virgo detchar message **right now**. This can be changed later as we come to know how virgo responds to hardware injections/ provides dq information.

vetoes messages look like the following:
>Testing gstlal V1 veto channel: this event IS NOT vetoed

OR

>Testing gstlal V1 veto channel: this event IS vetoed

hardware injection message look like the following:
>Testing V1 hardware injection: FOUND injections

OR

>Testing V1 hardware injection: DID NOT FIND injections

New testing script __one\_fake\_gstlal\_virgodq.sh__ added. But it essentially is not very different from __one\_fake\_gstlal\_triple.sh__ script, just the arguments used to build the testing (or write the config file to be passed to simulate.py) are different. We could probably still keep both, maybe modify the latter to keep it simple (without the virgo checks) and the former with the fake  virgo detchar messages.

Also my fork of lvalertTest is modifed to fake these virgo detchar message, so long as we are pulling the latest commit of that(which we are I believe), no further changes are needed to __setupTestListener.sh__